### PR TITLE
Changed File::Slurp to File::Slurp::Tiny

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -40,7 +40,7 @@ requires:
   Exporter: 0
   ExtUtils::MakeMaker: 6.56
   File::Copy: 0
-  File::Slurp: 0
+  File::Slurp::Tiny: 0
   Getopt::Long::Descriptive: 0
   Hash::Util: 0
   IO: 0

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -41,7 +41,7 @@ requires(
     'Exporter'                  => 0,
     'ExtUtils::MakeMaker'       => 6.56,
     'File::Copy'                => 0,
-    'File::Slurp'               => 0,
+    'File::Slurp::Tiny'         => 0,
     'Getopt::Long::Descriptive' => 0,
     'Hash::Util'                => 0,
     'IO'                        => 0,

--- a/README.pod
+++ b/README.pod
@@ -70,7 +70,7 @@ This distribution requires the following modules:
 
 =item * L<CPAN::Meta>
 
-=item * L<File::Slurp>
+=item * L<File::Slurp::Tiny>
 
 =item * L<Getopt::Long::Descriptive>
 

--- a/lib/Pod/Readme/Filter.pm
+++ b/lib/Pod/Readme/Filter.pm
@@ -13,7 +13,7 @@ use MooX::HandlesVia;
 with 'Pod::Readme::Plugin';
 
 use Carp;
-use File::Slurp qw/ read_file /;
+use File::Slurp::Tiny qw/ read_file /;
 use IO qw/ File Handle /;
 use Module::Load qw/ load /;
 use Path::Tiny;

--- a/t/data/META-1.yml
+++ b/t/data/META-1.yml
@@ -25,7 +25,7 @@ requires:
   CPAN::Changes: 0
   CPAN::Meta: 0
   ExtUtils::MakeMaker: 6.56
-  File::Slurp: 0
+  File::Slurp::Tiny: 0
   Hash::Util: 0
   IO: 0
   Module::CoreList: 0


### PR DESCRIPTION
Use of `File::Slurp` is discouraged (e.g. see [this](https://rt.cpan.org/Public/Bug/Display.html?id=83126)). This PR substitutes it for [File::Slurp::Tiny](https://metacpan.org/pod/File::Slurp::Tiny).

This PR is part of my [advent quest](https://questhub.io/realm/perl/quest/547b4202070ccf750d00010e).

Cheers,
Sergey.
