### PR TITLE
Change /{{/ in regex to /\{\{/

### DIFF
--- a/lib/Pod/Readme/Plugin/changes.pm
+++ b/lib/Pod/Readme/Plugin/changes.pm
@@ -128,7 +128,7 @@ sub cmd_changes {
 
     my %opts;
     if ($self->zilla) {
-      $opts{next_token} = qr/{{\$NEXT}}/;
+      $opts{next_token} = qr/\{\{\$NEXT}}/;
     }
 
     my $changes = CPAN::Changes->load($file, %opts);


### PR DESCRIPTION
Perl v5.22 is deprecating unescaped left braces in a regular expression
pattern.  This module has been broken since this was put into effect in
v5.21.2:
http://www.cpantesters.org/cpan/report/a9a07ed6-7c7b-11e4-ad19-d06752b25338

This was just brought to my attention by
https://rt.perl.org/Ticket/Display.html?id=122146#txn-1321681

Even though no warning messages were being displayed, the test was
failing.  I looked for left braces through the code and found these two.
When I add the backslashes, the tests start passing again.  There should
be no harm in escaping any punctuation character in a pattern in any
Perl 5 release, so this should work in any version.
