### PR TITLE
Import any from List::MoreUtils #10

### DIFF
--- a/lib/Pod/Readme.pm
+++ b/lib/Pod/Readme.pm
@@ -187,7 +187,7 @@ extends 'Pod::Readme::Filter';
 
 use Carp;
 use IO qw/ File Handle /;
-use List::Util qw/ any /;
+use List::MoreUtils qw/ any /;
 use Module::Load qw/ load /;
 use Path::Tiny qw/ path tempfile /;
 use Types::Standard qw/ Bool Maybe Str /;


### PR DESCRIPTION
Somehow the error does not show up during the tests.
But it does when using `pod2readme`.