### PR TITLE
Removed the use of File::Slurp

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for Pod-Readme
   [Documentation]
   - Fixed minor typos.
 
+  [Enhancement]
+  - Removed use of File::Slurp.
+
 v1.2.3    2018-10-31 22:56:42+00:00 Europe/London
   [Bug Fixes]
   - Increased minimum version of Type::Tiny to 1.000000.

--- a/README.pod
+++ b/README.pod
@@ -70,8 +70,6 @@ This distribution requires the following modules:
 
 =item * L<CPAN::Meta>
 
-=item * L<File::Slurp>
-
 =item * L<Getopt::Long::Descriptive>
 
 =item * L<IO::String>

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,6 @@
 requires "CPAN::Changes" => "0.30";
 requires "CPAN::Meta" => "0";
 requires "Class::Method::Modifiers" => "0";
-requires "File::Slurp" => "0";
 requires "Getopt::Long::Descriptive" => "0";
 requires "Hash::Util" => "0";
 requires "List::Util" => "1.33";

--- a/lib/Pod/Readme/Filter.pm
+++ b/lib/Pod/Readme/Filter.pm
@@ -10,7 +10,6 @@ use MooX::HandlesVia;
 with 'Pod::Readme::Plugin';
 
 use Carp;
-use File::Slurp qw/ read_file /;
 use IO qw/ File Handle /;
 use Module::Load qw/ load /;
 use Path::Tiny;
@@ -80,7 +79,7 @@ has input_fh => (
 sub _build_input_fh {
     my ($self) = @_;
     if ( $self->input_file ) {
-        $self->input_file->openr;
+        $self->input_file->openr($self->encoding);
     }
     else {
         my $fh = IO::Handle->new;
@@ -104,7 +103,7 @@ has output_fh => (
 sub _build_output_fh {
     my ($self) = @_;
     if ( $self->output_file ) {
-        $self->output_file->openw;
+        $self->output_file->openw($self->encoding);
     }
     else {
         my $fh = IO::Handle->new;
@@ -341,8 +340,7 @@ sub filter_line {
 sub filter_file {
     my ($self) = @_;
 
-    foreach
-      my $line ( read_file( $self->input_fh, binmode => $self->encoding ) )
+    while ( my $line = readline($self->input_fh) )
     {
         $self->filter_line($line)
           or last;

--- a/lib/Pod/Readme/Types.pm
+++ b/lib/Pod/Readme/Types.pm
@@ -116,7 +116,7 @@ sub Dir {
 
 =head2 C<File>
 
-A file. Can be a string or L<Path::Tiny> object.
+A file. Coerces a string to a L<Path::Tiny> object.
 
 =cut
 

--- a/t/data/META-1.yml
+++ b/t/data/META-1.yml
@@ -25,7 +25,6 @@ requires:
   CPAN::Changes: 0
   CPAN::Meta: 0
   ExtUtils::MakeMaker: 6.56
-  File::Slurp: 0
   Hash::Util: 0
   IO: 0
   Module::CoreList: 0


### PR DESCRIPTION
Since we already have Path::Tiny opening the filehandle, we can simply
use that directly.