### PR TITLE
Bump Minimum Perl Version to 5.12

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -83,6 +83,9 @@ x_authority = cpan:RRWO
 [MetaJSON]
 [MetaYAML]
 
+[MinimumPerl]
+perl = 5.012
+
 [InstallGuide]
 
 [Prereqs / TestRequires ]


### PR DESCRIPTION
Fixes #31

The recent Getopt-Long-Descriptive v0.110 now requires
Perl v5.12.0 or later.